### PR TITLE
Update visualize.py, compatibility with newer torchvision versions

### DIFF
--- a/torchgan/logging/visualize.py
+++ b/torchgan/logging/visualize.py
@@ -495,7 +495,7 @@ class ImageVisualize(Visualize):
                 with torch.no_grad():
                     image = generator(*self.test_noise[pos])
                     image = torchvision.utils.make_grid(
-                        image, nrow=self.nrow, normalize=True, range=(-1, 1)
+                        image, nrow=self.nrow, normalize=True, value_range=(-1, 1)
                     )
                     super(ImageVisualize, self).__call__(
                         trainer, image, model, **kwargs


### PR DESCRIPTION
torchvision 0.9 and above use parameter "value_range" rather than "range". 

Tested with torchvision 0.19.0 and pytorch 2.4.0 to run tutorial 5.